### PR TITLE
fix(module): rename to matelang/v3 (closes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,23 @@
 [![Security](https://github.com/matelang/go-ethereum-aws-kms-tx-signer/actions/workflows/security.yml/badge.svg)](https://github.com/matelang/go-ethereum-aws-kms-tx-signer/actions/workflows/security.yml)
 [![CodeQL](https://github.com/matelang/go-ethereum-aws-kms-tx-signer/actions/workflows/codeql.yml/badge.svg)](https://github.com/matelang/go-ethereum-aws-kms-tx-signer/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/matelang/go-ethereum-aws-kms-tx-signer/badge)](https://scorecard.dev/viewer/?uri=github.com/matelang/go-ethereum-aws-kms-tx-signer)
+[![Go Reference](https://pkg.go.dev/badge/github.com/matelang/go-ethereum-aws-kms-tx-signer/v3.svg)](https://pkg.go.dev/github.com/matelang/go-ethereum-aws-kms-tx-signer/v3)
+[![Go Report Card](https://goreportcard.com/badge/github.com/matelang/go-ethereum-aws-kms-tx-signer/v3)](https://goreportcard.com/report/github.com/matelang/go-ethereum-aws-kms-tx-signer/v3)
 [![License](https://img.shields.io/github/license/matelang/go-ethereum-aws-kms-tx-signer)](LICENSE)
 
-```
-⚠️This repo was recently moved to `matelang/go-ethereum-aws-kms-tx-signer` 
-from `welthee/go-ethereum-aws-kms-tx-signer`.
+> **v3 release**: the module path is now
+> `github.com/matelang/go-ethereum-aws-kms-tx-signer/v3`. v2 consumers
+> on `github.com/welthee/...` or `github.com/matelang/...v2` should
+> upgrade — those paths are no longer maintained.
 
-Update your import paths accordingly.
-```
-
-This little package eases integration with AWS KMS in your GoLang Ethereum project, by extending the functionality
-offered by the official go-ethereum library.
+This package eases integration with AWS KMS in your Go Ethereum project,
+by extending the functionality offered by the official `go-ethereum`
+library.
 
 ## Import
 
 ```go
-import "github.com/matelang/go-ethereum-aws-kms-tx-signer/v2"
+import "github.com/matelang/go-ethereum-aws-kms-tx-signer/v3"
 ```
 
 ## Usage
@@ -83,12 +84,29 @@ signedTx, _ := transactOpts.Signer(transactOpts.From, tx)
 err = client.SendTransaction(context.TODO(), signedTx)
 ```
 
-# Further reading
-* [Signing and Verifying Ethereum Signatures](https://yos.io/2018/11/16/ethereum-signatures/)
-* [EIP-155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155)
-* [The Dark Side of the Elliptic Curve - Signing Ethereum Transactions with AWS KMS in JavaScript](https://luhenning.medium.com/the-dark-side-of-the-elliptic-curve-signing-ethereum-transactions-with-aws-kms-in-javascript-83610d9a6f81)
+## Versioning
 
-# History
-This package was originally created for [welthee](https://welthee.com), and donated to the community as open source.
-Since the company could not provide a maintainer for this package, it was moved to the [matelang], where it is now maintained.
-I am the original author of this package, and I am happy to continue maintaining it.
+Tags follow Go's [semantic import versioning](https://go.dev/ref/mod#versions).
+The module path includes the major-version suffix, so a major-version bump
+requires updating both the tag (`vX.Y.Z`) and the import path
+(`.../vX`).
+
+| Module path                                            | Status                                |
+|--------------------------------------------------------|---------------------------------------|
+| `github.com/matelang/go-ethereum-aws-kms-tx-signer/v3` | **current**, maintained               |
+| `github.com/matelang/go-ethereum-aws-kms-tx-signer/v2` | unreleased; never had a `v2.x.x` tag  |
+| `github.com/welthee/go-ethereum-aws-kms-tx-signer/v2`  | abandoned upstream                    |
+| `github.com/welthee/go-ethereum-aws-kms-tx-signer`     | `v0.1.x` historical                   |
+
+## Further reading
+
+- [Signing and Verifying Ethereum Signatures](https://yos.io/2018/11/16/ethereum-signatures/)
+- [EIP-155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155)
+- [The Dark Side of the Elliptic Curve - Signing Ethereum Transactions with AWS KMS in JavaScript](https://luhenning.medium.com/the-dark-side-of-the-elliptic-curve-signing-ethereum-transactions-with-aws-kms-in-javascript-83610d9a6f81)
+
+## History
+
+This package was originally created for [welthee](https://welthee.com)
+and donated to the community as open source. Since the company could not
+provide a maintainer, it was moved to `matelang/` where it continues to
+be maintained by the original author.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/welthee/go-ethereum-aws-kms-tx-signer/v2
+module github.com/matelang/go-ethereum-aws-kms-tx-signer/v3
 
 go 1.25.7
 

--- a/signer_test.go
+++ b/signer_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
-	ethawskmssigner "github.com/welthee/go-ethereum-aws-kms-tx-signer/v2"
+	ethawskmssigner "github.com/matelang/go-ethereum-aws-kms-tx-signer/v3"
 )
 
 // Set INTEGRATION_KEY_ID, INTEGRATION_ETH_RPC, and (optionally) INTEGRATION_RECIPIENT


### PR DESCRIPTION
> **Stacked on #30** — base is `chore/ci-docs-parity`. Merge that one first;
> this PR auto-retargets to `main` once it does.

## What

Renames the module path from
`github.com/welthee/go-ethereum-aws-kms-tx-signer/v2` (declared) to
`github.com/matelang/go-ethereum-aws-kms-tx-signer/v3` (consumed).
Closes #29.

## Why

The repo was migrated `welthee/` → `matelang/` last year but `go.mod`
still declared the old `welthee/...v2` path. As a result, anyone
running

```
go get github.com/matelang/go-ethereum-aws-kms-tx-signer/v2
```

would fail with a module-path mismatch (#29 has the full error).

Per the discussion on the PR-strategy thread, cutting to `/v3` rather
than fixing `/v2` in place:

- communicates the maintainer change cleanly
- pairs naturally with the upcoming EIP-712 typed-data addition (PR 3)
- gives consumers a single migration step instead of two

## How

- `go.mod`: module path → `github.com/matelang/.../v3`
- `signer_test.go`: import path → `.../v3`
- `README.md`:
  - Import example updated to `/v3`
  - Migration banner rewritten to point `v2` / `welthee` consumers at v3
  - Added `pkg.go.dev` and `goreportcard` badges on the new path
  - New **Versioning** table documenting which paths are maintained
  - History section cleaned up

`go.sum` is unchanged — module-path is metadata, not a dep.

## Release plan

After this lands on `main`, cut an annotated tag `v3.0.0`:

```
git tag -as v3.0.0 -m "v3.0.0 — module path rename to matelang/v3"
git push origin v3.0.0
```

That makes `go get github.com/matelang/go-ethereum-aws-kms-tx-signer/v3`
resolve to a real semver tag instead of a pseudo-version.

## Backward compatibility

This is a major-version bump. Consumers on `welthee/...v2` (or the
phantom `matelang/...v2`) must update their imports. There are no
API changes — only the module path moves.

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes (`0 issues`)
- [x] `go mod tidy` is a no-op
- [x] No remaining `welthee` references in Go/mod files (only the
      intentional historical mentions in README)

## Security

- [x] No code path changes; signing, verification, and key handling
      are byte-for-byte identical.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)